### PR TITLE
feat: diaries 테이블에 is_analyzed 컬럼 추가 및 뷰 제거, useDiaries 수정

### DIFF
--- a/src/pages/analysis/EmotionAndQuest/index.tsx
+++ b/src/pages/analysis/EmotionAndQuest/index.tsx
@@ -52,6 +52,7 @@ function EmotionAndQuest() {
           user_id: user.id,
           reason_text: reason || null,
           is_quest_accepted: accepted,
+          is_public: true // 임시로 true로 했음!!!!!!!!!!!!!!!!!!!!!
         })
         .select()
         .single();
@@ -80,6 +81,18 @@ function EmotionAndQuest() {
           user_id: user.id,
         }));
         await supabase.from('user_accepted_quests').insert(questRows);
+      }
+
+      // 4. diaries 테이블 is_analyzed 컬럼 true로 저장
+      const {error: updateError} = await supabase
+        .from('diaries')
+        .update({ is_analyzed: true })
+        .eq('id', diaryId)
+        .eq('user_id', user.id);
+
+      if (updateError) {
+        console.error('is_analyzed 업데이트 실패:', updateError);
+        return;
       }
 
       toastUtils.success({ title: '성공', message: '분석이 저장되었습니다.' })

--- a/src/pages/analysis/SelectDiary/hooks/useDiaries.ts
+++ b/src/pages/analysis/SelectDiary/hooks/useDiaries.ts
@@ -26,9 +26,10 @@ export function useDiaries(userId?: string, isAuth?: boolean) {
       const isoStartDate = startDate.toISOString();
 
       const { data, error } = await supabase
-        .from('diaries_unanalyzed')   // 뷰 사용
-        .select('*')
+        .from('diaries')
+        .select('id, title, content, created_at')
         .eq('user_id', userId)
+        .eq('is_analyzed', false)
         .gte('created_at', isoStartDate) // 14일 이내
         .order('created_at', { ascending: false });
 

--- a/src/shared/api/supabase/types.ts
+++ b/src/shared/api/supabase/types.ts
@@ -77,6 +77,7 @@ export type Database = {
           diary_image: string | null
           emotion_main_id: number
           id: string
+          is_analyzed: boolean
           is_drafted: boolean
           is_public: boolean
           title: string
@@ -85,10 +86,11 @@ export type Database = {
         }
         Insert: {
           content: string
-          created_at?: string
+          created_at: string
           diary_image?: string | null
           emotion_main_id: number
           id?: string
+          is_analyzed?: boolean
           is_drafted?: boolean
           is_public: boolean
           title: string
@@ -101,6 +103,7 @@ export type Database = {
           diary_image?: string | null
           emotion_main_id?: number
           id?: string
+          is_analyzed?: boolean
           is_drafted?: boolean
           is_public?: boolean
           title?: string
@@ -115,6 +118,13 @@ export type Database = {
             referencedRelation: "emotion_mains"
             referencedColumns: ["id"]
           },
+          {
+            foreignKeyName: "diaries_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
         ]
       }
       diary_analysis: {
@@ -122,6 +132,7 @@ export type Database = {
           created_at: string | null
           diary_id: string
           id: string
+          is_public: boolean
           is_quest_accepted: boolean
           reason_text: string | null
           user_id: string
@@ -130,6 +141,7 @@ export type Database = {
           created_at?: string | null
           diary_id: string
           id?: string
+          is_public: boolean
           is_quest_accepted?: boolean
           reason_text?: string | null
           user_id: string
@@ -138,6 +150,7 @@ export type Database = {
           created_at?: string | null
           diary_id?: string
           id?: string
+          is_public?: boolean
           is_quest_accepted?: boolean
           reason_text?: string | null
           user_id?: string
@@ -276,6 +289,7 @@ export type Database = {
           id: string
           is_read: boolean
           message: string
+          sender_id: string
           title: string
           type: Database["public"]["Enums"]["notification_type"]
           user_id: string
@@ -285,6 +299,7 @@ export type Database = {
           id?: string
           is_read?: boolean
           message: string
+          sender_id: string
           title: string
           type: Database["public"]["Enums"]["notification_type"]
           user_id: string
@@ -294,6 +309,7 @@ export type Database = {
           id?: string
           is_read?: boolean
           message?: string
+          sender_id?: string
           title?: string
           type?: Database["public"]["Enums"]["notification_type"]
           user_id?: string
@@ -304,6 +320,13 @@ export type Database = {
             columns: ["diary_id"]
             isOneToOne: false
             referencedRelation: "diaries"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "notifications_sender_id_fkey"
+            columns: ["sender_id"]
+            isOneToOne: false
+            referencedRelation: "users"
             referencedColumns: ["id"]
           },
         ]
@@ -432,9 +455,7 @@ export type Database = {
       }
     }
     Views: {
-      diaries_unanalyzed: {
-        Row: Database['public']['Tables']['diaries']['Row'];
-      }
+      [_ in never]: never
     }
     Functions: {
       [_ in never]: never


### PR DESCRIPTION
## 작업 개요

`diaries` 테이블 `is_analyzed` 컬럼 추가 및 뷰 제거, `useDiaries` 수정

## 작업내용
- [x] `diaries` 테이블에 `is_analyzed` 컬럼 추가 (BOOLEAN, 기본값 false)
- [x] `diaries_unanalyzed` 뷰 삭제
- [x] `useDiaries` 훅을 뷰 대신 `is_analyzed` 기반으로 14일 이내 미분석 일기 조회하도록 수정
- [x] `diary_analysis` 저장 시 `is_public: true`로 임시 처리 (토글 적용 예정)

## 관련 이슈
