### PR TITLE
Feature/102 analysis public result 2

### DIFF
--- a/src/pages/analysis/EmotionAndQuest/components/DiaryViewer/index.tsx
+++ b/src/pages/analysis/EmotionAndQuest/components/DiaryViewer/index.tsx
@@ -1,4 +1,4 @@
-import S from '../style.module.css';
+import S from '@/pages/analysis/EmotionAndQuest/style.module.css';
 
 interface Props {
   content: string;

--- a/src/pages/analysis/EmotionAndQuest/components/EmotionSelector/index.tsx
+++ b/src/pages/analysis/EmotionAndQuest/components/EmotionSelector/index.tsx
@@ -1,4 +1,4 @@
-import S from '../style.module.css';
+import S from '@/pages/analysis/EmotionAndQuest/style.module.css';
 import type { Database } from '@/shared/api/supabase/types';
 
 type EmotionSub = Database['public']['Tables']['emotion_subs']['Row'];

--- a/src/pages/analysis/EmotionAndQuest/components/PublicDecision/index.tsx
+++ b/src/pages/analysis/EmotionAndQuest/components/PublicDecision/index.tsx
@@ -1,0 +1,22 @@
+import Toggle from '@/shared/components/Toggle';
+import S from './style.module.css'
+
+interface Props {
+  isPublic: boolean;
+  onChange: (checked: boolean) => void;
+}
+
+function PublicDecision({ isPublic, onChange }: Props) {
+  return (
+    <section className={S.publicSection}>
+      <h3>분석 결과를 다른 사람에게 공개해보세요</h3>
+      <Toggle
+        checked={isPublic}
+        onChange={onChange}
+        label="감정 분석 공개"
+        showLabel={false}
+      />
+    </section>
+  )
+}
+export default PublicDecision

--- a/src/pages/analysis/EmotionAndQuest/components/PublicDecision/style.module.css
+++ b/src/pages/analysis/EmotionAndQuest/components/PublicDecision/style.module.css
@@ -1,0 +1,9 @@
+
+
+.publicSection {
+  margin-bottom: 60px;
+
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}

--- a/src/pages/analysis/EmotionAndQuest/components/QuestDecision/index.tsx
+++ b/src/pages/analysis/EmotionAndQuest/components/QuestDecision/index.tsx
@@ -1,4 +1,4 @@
-import S from '../style.module.css';
+import S from '@/pages/analysis/EmotionAndQuest/style.module.css';
 
 interface Props {
   accepted: boolean | null;

--- a/src/pages/analysis/EmotionAndQuest/components/QuestSelector/index.tsx
+++ b/src/pages/analysis/EmotionAndQuest/components/QuestSelector/index.tsx
@@ -1,4 +1,4 @@
-import S from '../style.module.css';
+import S from '@/pages/analysis/EmotionAndQuest/style.module.css';
 import type { Database } from '@/shared/api/supabase/types';
 
 type Quest = Database['public']['Tables']['quests']['Row'];

--- a/src/pages/analysis/EmotionAndQuest/components/ReasonInput/index.tsx
+++ b/src/pages/analysis/EmotionAndQuest/components/ReasonInput/index.tsx
@@ -1,4 +1,4 @@
-import S from '../style.module.css';
+import S from '@/pages/analysis/EmotionAndQuest/style.module.css';
 
 interface Props {
   value: string;

--- a/src/pages/analysis/EmotionAndQuest/index.tsx
+++ b/src/pages/analysis/EmotionAndQuest/index.tsx
@@ -11,6 +11,7 @@ import QuestSelector from './components/QuestSelector';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useToggleList } from './hooks/useToggleList';
 import { toastUtils } from '@/shared/components/Toast';
+import PublicDecision from './components/PublicDecision';
 
 function EmotionAndQuest() {
   const location = useLocation();
@@ -24,6 +25,8 @@ function EmotionAndQuest() {
   const questSelection = useToggleList(); // 퀘스트 선택
   const [questAccepted, setQuestAccepted] = useState<boolean | null>(null);
   const [reason, setReason] = useState('');
+
+  const [isPublic, setIsPublic] = useState(false);
 
 
   useEffect(() => {
@@ -52,7 +55,7 @@ function EmotionAndQuest() {
           user_id: user.id,
           reason_text: reason || null,
           is_quest_accepted: accepted,
-          is_public: true // 임시로 true로 했음!!!!!!!!!!!!!!!!!!!!!
+          is_public: isPublic  // 토글 상태로 저장
         })
         .select()
         .single();
@@ -124,6 +127,7 @@ function EmotionAndQuest() {
         onToggle={emotionSelection.toggle}
       />
       <ReasonInput value={reason} onChange={setReason} />
+      
       <QuestDecision
         accepted={questAccepted}
         onAccept={() => setQuestAccepted(true)}
@@ -136,17 +140,24 @@ function EmotionAndQuest() {
           onToggle={questSelection.toggle}
         />
       )}
+
       {questAccepted !== null && (
-        <section className={S.submitSection}>
-          <button
-            type="button"
-            className={S.submit}
-            onClick={handleSubmit}
-            disabled={emotionSelection.selected.length === 0}
-          >
-            완료
-          </button>
-        </section>
+        <>
+          <PublicDecision
+              isPublic={isPublic}
+              onChange={setIsPublic}
+          />
+          <section className={S.submitSection}>
+            <button
+              type="button"
+              className={S.submit}
+              onClick={handleSubmit}
+              disabled={emotionSelection.selected.length === 0}
+            >
+              완료
+            </button>
+          </section>
+        </>
       )}
     </main>
   );

--- a/src/shared/components/CheckBox/index.tsx
+++ b/src/shared/components/CheckBox/index.tsx
@@ -1,0 +1,27 @@
+import S from './style.module.css'
+
+interface Props {
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+  label: string;
+  size?: number;
+}
+
+function CheckBox({ checked, onChange, label, size = 18 }:Props) {
+  return (
+    <div className={S.wrapper}>
+      <input
+        type='checkbox'
+        className={S.checkbox}
+        checked={checked}
+        onChange={(e) => onChange(e.target.checked)}
+        aria-label={`${label} 체크박스`}
+        style={{
+          width: `${size}px`,
+          height: `${size}px`
+        }}
+      />
+    </div>
+  )
+}
+export default CheckBox

--- a/src/shared/components/CheckBox/style.module.css
+++ b/src/shared/components/CheckBox/style.module.css
@@ -4,7 +4,5 @@
 }
 
 .checkbox {
-  width: 30px;
-  height: 30px;
   accent-color: var(--primary);
 }

--- a/src/shared/components/CheckBox/style.module.css
+++ b/src/shared/components/CheckBox/style.module.css
@@ -1,0 +1,10 @@
+.wrapper {
+  display: inline-flex;
+  align-items: center;
+}
+
+.checkbox {
+  width: 30px;
+  height: 30px;
+  accent-color: var(--primary);
+}

--- a/src/shared/components/Toggle/index.tsx
+++ b/src/shared/components/Toggle/index.tsx
@@ -1,0 +1,31 @@
+import S from './style.module.css';
+
+interface Props {
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+  label?: string;
+  showLabel?: boolean;
+}
+
+function Toggle({ checked, onChange, label, showLabel = true }:Props) {
+  const ariaLabel = label ? `${label} 토글 버튼` : '토글 버튼';
+
+  return (
+    <div className={S.wrapper}>
+      <button
+        type="button"
+        className={`${S.toggle} ${checked ? S.on : ''}`}
+        onClick={() => onChange(!checked)}
+        aria-label= {ariaLabel}
+        aria-pressed={checked}
+      >
+        <span className={S.circle} />
+      </button>
+
+      {label && showLabel && (
+        <span className={S.label}>{label}</span>
+      )}
+    </div>
+  );
+}
+export default Toggle

--- a/src/shared/components/Toggle/style.module.css
+++ b/src/shared/components/Toggle/style.module.css
@@ -1,0 +1,44 @@
+.wrapper {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.toggle {
+  position: relative;
+  width: 64px;
+  height: 36px;
+  border-radius: 999px;
+  background-color: var(--gray-100);
+  transition: background-color 0.2s ease;
+  cursor: pointer;
+  border: none;
+  padding: 0;
+}
+
+.on {
+  background-color: var(--primary);
+}
+
+.circle {
+  position: absolute;
+  top: 4px;
+  left: 4px;
+  width: 28px;
+  height: 28px;
+  background-color: #fff;
+  border-radius: 50%;
+  transition: transform 0.3s ease;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.2)
+}
+
+.on .circle {
+  transform: translateX(28px);
+}
+
+.label {
+  display: flex;
+  align-items: center;
+  font-size: var(--text-base);
+  color: var(--gray-500);
+}


### PR DESCRIPTION
## 작업 개요

감정분석 공개/비공개 UI와 저장 기능

## 작업내용

- [x] `pages/analysis/EmotionAndQuest/components` 폴더 구조 변경
- [x] `diary_analysis` 테이블 `is_public`에 토글 상태값을  저장
- [x] Toggle, CheckBox 공용 컴포넌트 만들어서 `shared/components`에 저장
- [x] 토글 on/off 상태가 더 잘 구분되도록 색상 개선
    - on/off 넣으려면 태그 넣어야 해서 off 일 때 배경색을 바꿔봤는데 괜찮은 거 같아서 일단 이렇게 했습니다.

## 관련 이슈
closes #102 