### PR TITLE
feat: 일기 상세 페이지에 AI 감정 분석 결과 표시

### DIFF
--- a/src/pages/Diary/DiaryDetail/components/AnalysisResult/index.tsx
+++ b/src/pages/Diary/DiaryDetail/components/AnalysisResult/index.tsx
@@ -17,6 +17,13 @@ function AnalysisResult({ diaryId, isAuthor }: Props) {
   if (loading || !analysis) return null; // 로딩 중이거나 감정 분석 안 했으면 렌더 x
   if (!isAuthor && !analysis.is_public) return null; // 작성자가 아니고 비공개면 렌더 x
 
+  const hasAIAnalysis =
+  analysis.empathy &&
+  analysis.emotionalTriggers &&
+  analysis.emotionInterpretation &&
+  analysis.reminderMessage &&
+  analysis.selfReflectionSuggestion;
+
   return (
     <div className={S.divider}>
       <div className={S.container}>
@@ -30,21 +37,50 @@ function AnalysisResult({ diaryId, isAuthor }: Props) {
 
         {isOpen && (
           <div className={S.analysisResult}>
-            <section className={S.emotionSection}>
-              <h4>감정</h4>
-              <div className={S.emotions}>
-                {analysis.emotions.map((emotion) => (
-                  <span key={emotion.id} className={S.emotionTag}>
-                    {emotion.name}
-                  </span>
-                ))}
+            <section className={S.selfSection}>
+              <h4>내가 기록한 감정과 이유</h4>
+              <div className={S.analysisBox}>
+                <div className={S.analysisItem}>
+                  <p>[내가 느낀 감정들]</p>
+                  <div className={S.emotions}>
+                    {analysis.emotions.map((emotion) => (
+                      <span key={emotion.id} className={S.emotionTag}>
+                        {emotion.name}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+                <div className={S.analysisItem}>
+                  <p>[그렇게 느낀 이유]</p>
+                  <span>{analysis.reason}</span>
+                </div>
               </div>
             </section>
 
-            <section className={S.reasonSection}>
-              <h4>이유</h4>
-              <p>{analysis.reason}</p>
-            </section>
+            {hasAIAnalysis && (
+              <section className={S.aiSection}>
+                <h4>몰리의 감정 분석 결과</h4>
+                <div className={S.analysisBox}>
+                  <p className={S.empathy}>{analysis.empathy}</p>
+                  <div className={S.analysisItem}>
+                    <p>[감정 유발 요인]</p>
+                    <span>{analysis.emotionalTriggers}</span>
+                  </div>
+                  <div className={S.analysisItem}>
+                    <p>[감정 해석]</p>
+                    <span>{analysis.emotionInterpretation}</span>
+                  </div>
+                  <div className={S.analysisItem}>
+                    <p>[리마인드]</p>
+                    <span>{analysis.reminderMessage}</span>
+                  </div>
+                  <div className={S.analysisItem}>
+                    <p>[자기성찰]</p>
+                    <span>{analysis.selfReflectionSuggestion}</span>
+                  </div>
+                </div>
+              </section>
+            )}
           </div>
         )}
       </div>

--- a/src/pages/Diary/DiaryDetail/components/AnalysisResult/style.module.css
+++ b/src/pages/Diary/DiaryDetail/components/AnalysisResult/style.module.css
@@ -4,6 +4,13 @@
   overflow: hidden;
 }
 
+/* 상단 구분선 */
+.divider {
+  border-top: 1px solid var(--gray-100);
+  margin-top: 20px;
+  padding-top: 20px;
+}
+
 /* 감정 분석 결과 */
 .header {
   display: flex;
@@ -17,7 +24,7 @@
 }
 
 /* 도장 + 감정 분석 결과 문구 */
-.headerLeft { 
+.headerLeft {
   display: flex;
   align-items: center;
   gap: 6px;
@@ -36,59 +43,128 @@
 
 /* isOpen */
 .analysisResult {
-  padding: 24px 52px;
-}
+  padding: 24px 52px 40px 52px;
 
-/* 감정 섹션 */
-.emotionSection{
-  margin-bottom: var(--space-8);
-
-  /* 감정 태그 리스트 */
-  .emotions {
-    display: flex;
-    flex-wrap: wrap;
-    gap: var(--space-3);
-  }
-
-  /* 감정 태그 */
-  .emotionTag {
-    padding: var(--space-2) var(--space-4);
-    border-radius: 9999px;
-    background-color: var(--gray-100);
-    color: var(--gray-900);
-    font-size: var(--text-base);
-    font-weight: 500;
-    line-height: var(--space-5);
-  }
-}
-
-/* 감정, 이유 섹션 공통 */
-.emotionSection,
-.reasonSection {
-
-  /* 감정, 이유 */
+  /* 내가 기록한 감정과 이유, 몰리의 감정 분석 결과 */
   h4 {
     color: var(--primary);
     font-size: var(--text-2xl);
     font-weight: 500;
     margin-bottom: var(--space-3);
   }
+}
 
-  /* 이유 */
-  p {
-    color: var(--gray-900);
-    font-size: var(--text-lg);
-    line-height: var(--space-5);
-    /* font-weight: 500; */
-    
-    word-break: keep-all;
-    overflow-wrap: break-word;
+.aiSection {
+  margin-top: 32px;
+}
+
+.analysisBox {
+  padding: var(--space-5);
+  background-color: #ffffff;
+  border-radius: var(--radius-3);
+  border: 1px solid #e5e7eb;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.04);
+}
+
+.analysisItem {
+  margin-bottom: 20px;
+  padding: 16px;
+  background-color: #fafbfc;
+  border-radius: 8px;
+  border: 1px solid #f1f3f4;
+
+  &:last-child {
+      margin-bottom: 0;
   }
 }
 
-/* 상단 구분선 */
-.divider {
-  border-top: 1px solid var(--gray-100);
-  margin-top: 20px;
-  padding-top: 20px;
+.analysisItem p {
+  font-size: 14px;
+  font-weight: 600;
+  color: #1f2937;
+  margin: 0 0 8px 0;
+  padding-bottom: 4px;
+  border-bottom: 1px solid #e5e7eb;
+}
+
+.analysisItem span {
+  font-size: 15px;
+  color: #4b5563;
+  line-height: 1.6;
+  display: block;
+  white-space: pre-line;
+}
+
+.empathy {
+  font-size: var(--text-lg);
+  font-weight: 500;
+  color: #374151;
+  line-height: 1.6;
+  margin-bottom: 24px;
+  padding: var(--space-4);
+  background-color: #f8fafc;
+  border-radius: var(--radius-2);
+}
+
+/* 감정 태그 리스트 */
+.emotions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+}
+
+/* 감정 태그 */
+.emotionTag {
+  padding: var(--space-1) var(--space-3);
+  border-radius: 9999px;
+  background-color: var(--gray-100);
+  color: var(--gray-900);
+  font-size: var(--text-base);
+  font-weight: 400;
+  line-height: var(--space-5);
+}
+
+
+@media (max-width: 768px) {
+  .headerLeft {
+    img {
+      width: 24px;
+      height: 24px;
+    }
+    
+    span {
+      font-size: var(--text-lg);
+    }
+  }
+
+  .analysisResult {
+    padding: 24px 36px 36px 36px;
+
+    h4 {
+      font-size: var(--text-xl);
+    }
+  }
+
+  .analysisBox {
+    padding: 16px;
+  }
+
+  .empathy {
+    font-size: 15px;
+    padding: 14px;
+    margin-bottom: 20px;
+  }
+
+  .analysisItem {
+    padding: 14px;
+    margin-bottom: 16px;
+
+    > p {
+      font-size: 13px;
+    }
+
+    > span {
+      font-size: 14px;
+    }
+  }
 }

--- a/src/pages/Diary/DiaryDetail/hooks/useDiaryAnalysis.ts
+++ b/src/pages/Diary/DiaryDetail/hooks/useDiaryAnalysis.ts
@@ -9,6 +9,11 @@ export function useDiaryAnalysis(diaryId: string) {
     reason: string | null;
     emotions: EmotionSub[];
     is_public: boolean;
+    empathy?: string | null;
+    emotionalTriggers?: string | null;
+    emotionInterpretation?: string | null;
+    reminderMessage?: string | null;
+    selfReflectionSuggestion?: string | null;
   } | null>(null);
 
   const [loading, setLoading] = useState(true);
@@ -21,6 +26,11 @@ export function useDiaryAnalysis(diaryId: string) {
         .select(`
           reason_text,
           is_public,
+          empathy,
+          emotionalTriggers,
+          emotionInterpretation,
+          reminderMessage,
+          selfReflectionSuggestion,
           user_selected_emotions (
             emotion_subs (*)
           )
@@ -41,6 +51,11 @@ export function useDiaryAnalysis(diaryId: string) {
         reason: data.reason_text, // 분석 이유 저장
         emotions: emotions ?? [], // 감정 저장
         is_public: data.is_public, // 공개 여부 저장
+        empathy: data.empathy, // 공감 메시지 저장
+        emotionalTriggers: data.emotionalTriggers, // 감정 유발 요인 저장
+        emotionInterpretation: data.emotionInterpretation, // 감정 해석 저장
+        reminderMessage: data.reminderMessage, // 리마인드 저장
+        selfReflectionSuggestion: data.selfReflectionSuggestion, // 자기성찰 저장
       });
 
       setLoading(false);

--- a/src/pages/Diary/diaryMain/hooks/useDiaryDetail.ts
+++ b/src/pages/Diary/diaryMain/hooks/useDiaryDetail.ts
@@ -5,7 +5,7 @@ import supabase from '@/shared/api/supabase/client';
 import { type DiaryDetailEntity, type DisplayComment } from '@/shared/types/diary';
 import { toastUtils } from '@/shared/components/Toast';
 import { useUserContext } from '@/shared/context/UserContext';
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { postCommentNotification } from '@/shared/api/comment';
 
 export const useDiaryDetail = (diaryId: string | undefined) => {
@@ -18,6 +18,12 @@ export const useDiaryDetail = (diaryId: string | undefined) => {
   const [author, setAuthor] = useState<{ name: string } | null>(null);
 
   const { userInfo } = useUserContext();
+
+  const hasFetched = useRef(false);
+
+  useEffect(() => {
+    hasFetched.current = false;
+  }, [diaryId]);
 
   const fetchComments = useCallback(async (diaryId: string) => {
     try {
@@ -71,6 +77,8 @@ export const useDiaryDetail = (diaryId: string | undefined) => {
       return;
     }
 
+    if (hasFetched.current) return;
+
     setLoading(true);
     setError(null);
 
@@ -92,6 +100,8 @@ export const useDiaryDetail = (diaryId: string | undefined) => {
         setAuthor(authorData);
       }
       await fetchComments(diaryId);
+
+      hasFetched.current = true;
     } catch (error) {
       const errorMessage =
         error instanceof Error ? error.message : '알 수 없는 오류가 발생했습니다.';

--- a/src/pages/analysis/EmotionAndQuest/index.tsx
+++ b/src/pages/analysis/EmotionAndQuest/index.tsx
@@ -119,7 +119,7 @@ function EmotionAndQuest() {
 
       toastUtils.success({ title: '성공', message: '분석이 저장되었습니다.' });
 
-      navigate('/', { replace: true });
+      navigate('/home', { replace: true });
     } catch (err) {
       console.error('저장 중 오류 발생:', err);
     }

--- a/src/pages/analysis/EmotionAndQuest/style.module.css
+++ b/src/pages/analysis/EmotionAndQuest/style.module.css
@@ -4,6 +4,7 @@
   max-width: 896px;
   margin: 0 auto;
   padding-top: 80px; /* 헤더 높이 */
+  padding-inline: 20px;
 
   h3{
     color: var(--gray-900, #303030);

--- a/src/pages/analysis/SelectDiary/hooks/useDiaries.ts
+++ b/src/pages/analysis/SelectDiary/hooks/useDiaries.ts
@@ -34,7 +34,7 @@ export function useDiaries(userId?: string, isAuth?: boolean) {
         .order('created_at', { ascending: false });
 
       const loadTime = Date.now() - start;
-      const minDelay = 700; // 스피너 최소 시간
+      const minDelay = 500; // 스피너 최소 시간
       const delay = loadTime < minDelay ? (minDelay - loadTime) : 0;
 
       setTimeout(() => {

--- a/src/pages/analysis/SelectDiary/style.module.css
+++ b/src/pages/analysis/SelectDiary/style.module.css
@@ -4,49 +4,50 @@
   max-width: 896px;
   margin: 0 auto;
   padding-top: 80px; /* 헤더 높이 */
+  padding-inline: 20px;
+}
 
-  .intro{
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    flex-direction: column;
-    margin-top: 40px;     /* 헤더와 추가 간격 */
-    margin-bottom: 40px;
+.intro{
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+  margin-top: 40px;     /* 헤더와 추가 간격 */
+  margin-bottom: 40px;
 
-    h2{
-      color: var(--gray-900);
-      font-size: var(--text-4xl);
-      font-weight: 700;
-      line-height: 36px;
-      margin-bottom: var(--space-2);
-    }
-
-    p{
-      color: var(--gray-700);
-      font-size: var(--text-lg);
-      font-weight: 400;
-      line-height: 24px;
-    }
+  h2{
+    color: var(--gray-900);
+    font-size: var(--text-4xl);
+    font-weight: 700;
+    line-height: 36px;
+    margin-bottom: var(--space-2);
   }
 
-  .listWrapper {
-    margin-bottom: var(--space-8)
-  }
-
-  .loadMore {
-    align-self: center;
-    border: none;
-    border-radius: var(--radius-2);
-    background: var(--gray-100);
+  p{
+    color: var(--gray-700);
     font-size: var(--text-lg);
-    font-weight: 500;
-    padding: var(--space-3) var(--space-6);
-    cursor: pointer;
-    margin: 0 auto 50px;
+    font-weight: 400;
     line-height: 24px;
-    user-select: none;
-    display: block;
   }
+}
+
+.listWrapper {
+  margin-bottom: var(--space-8)
+}
+
+.loadMore {
+  align-self: center;
+  border: none;
+  border-radius: var(--radius-2);
+  background: var(--gray-100);
+  font-size: var(--text-lg);
+  font-weight: 500;
+  padding: var(--space-3) var(--space-6);
+  cursor: pointer;
+  margin: 0 auto 50px;
+  line-height: 24px;
+  user-select: none;
+  display: block;
 }
 
 .noDiaryState {
@@ -82,10 +83,6 @@
   color: var(--gray-500);
   font-weight: 500;
   line-height: var(--space-6);
-}
-
-.noStickyBtn {
-  /* margin-bottom: 40px; */
 }
 
 .stickyBtn {


### PR DESCRIPTION
## 작업 개요

일기 상세 페이지에 AI 감정 분석 결과 표시

## 작업내용

- [x] 일기 상세 페이지에 AI 감정 분석 결과 표시
- [x] 감정 분석 완료 후 이동 경로 /home으로 변경
- [x] 일기 선택, 감정 분석 페이지에 좌우 여백 기본 패딩 추가
- [x] 일기 선택 페이지 스피너 시간 수정
- [x] 일기 상세 페이지에서 브라우저 탭 전환 시 다시 패칭하는 문제 수정

## 관련 이슈

closes #141