### PR TITLE
fix: 반응형에서 빠르게 스크롤 시 무한스크롤 적용 안되는 문제 해결

### DIFF
--- a/src/pages/users/UserList/hooks/useUserLoader.ts
+++ b/src/pages/users/UserList/hooks/useUserLoader.ts
@@ -46,6 +46,7 @@ export const useUserLoader = (searchTerm: string) => {
   // 초기 로드
   useEffect(() => {
     const initialLoad = async () => {
+      await loadUsers(1);
       setInitialLoading(false);
     };
     initialLoad();


### PR DESCRIPTION
## 작업 개요

반응형에서 빠르게 스크롤 시 무한스크롤 적용 안되는 문제 해결

## 작업내용

- [x] 반응형에서 빠르게 스크롤 시 무한스크롤 적용 안되는 문제 해결

## 관련 이슈
