### PR TITLE
fix: 일기장 상세 에러문구 뜨는곳, 달력 작성완료 아이콘 오류

### DIFF
--- a/src/pages/diary/DiaryMain/hooks/useDiaryDetail.ts
+++ b/src/pages/diary/DiaryMain/hooks/useDiaryDetail.ts
@@ -71,9 +71,13 @@ export const useDiaryDetail = (diaryId: string | undefined) => {
   }, []);
 
   const fetchDiaryDetail = useCallback(async () => {
-    if (!diaryId || !userInfo) {
-      setError('일기 ID 또는 사용자 정보가 제공되지 않았습니다.');
+    if (!diaryId) {
+      setError('일기 ID가 제공되지 않았습니다.');
       setLoading(false);
+      return;
+    }
+
+    if (!userInfo) {
       return;
     }
 

--- a/src/shared/utils/dateUtils.ts
+++ b/src/shared/utils/dateUtils.ts
@@ -65,7 +65,12 @@ export const getKoreanDateRangeUTC = (date: Date) => {
 // UTC 시간을 한국 시간으로 변환해서 날짜 문자열 반환
 export const getKoreanDateStringFromUTC = (utcDate: string | Date): string => {
   const date = typeof utcDate === 'string' ? new Date(utcDate) : utcDate;
-  // UTC에서 한국 시간으로 변환 (UTC + 9시간)
-  const koreanDate = new Date(date.getTime() + 9 * 60 * 60 * 1000);
-  return getLocalDateString(koreanDate);
+
+  //UTC에서 한국 시간으로 변환 (UTC + 9시간)
+  const koreanTime = new Date(date.getTime() + 9 * 60 * 60 * 1000);
+  const year = koreanTime.getUTCFullYear();
+  const month = String(koreanTime.getUTCMonth() + 1).padStart(2, '0');
+  const day = String(koreanTime.getUTCDate()).padStart(2, '0');
+
+  return `${year}-${month}-${day}`;
 };


### PR DESCRIPTION
## 작업 개요

일기장 상세에서 새로고침 시 잠깐 에러 문구 노출, 달력 작성 완료 아이콘 오류

## 작업내용

- [x] 일기장 상세에서 새로고침 시 잠깐 에러 문구 노출
- [x] 달력 작성 완료 아이콘 오류

## 관련 이슈
